### PR TITLE
recipeのoutputをstrではなくそのままの状態にした

### DIFF
--- a/src/module/module.py
+++ b/src/module/module.py
@@ -5,11 +5,10 @@ import re
 import subprocess
 import json
 import jsonschema
-
 import utils
 
 class Module:
-    def __init__(self, module_name) -> None:
+    def __init__(self, module_name, states) -> None:
         """
         Args:
             module_name (_type_): 起動するモジュール名(NOTファイル名)
@@ -23,6 +22,7 @@ class Module:
         else:
             raise KeyError(f"Error: {module_name} is not found.")
         
+        self.states = states
         self.variables = {}
         
         with open(os.path.join("modules/json", self.module_path), 'r') as f:
@@ -36,6 +36,9 @@ class Module:
         # モジュール内変数の準備
         self.variables["input"] = []
         for arg_count, arg  in enumerate(args):
+            template_arg = utils.replace_template_nostr(self.states, arg)
+            if not template_arg is None:
+                arg = template_arg
             self.variables["input"].append(arg)
         
         if self.module_json["type"] == "built-in":

--- a/src/recipe/recipe.py
+++ b/src/recipe/recipe.py
@@ -7,7 +7,7 @@ import module.module as md
 import utils
 
 class Recipe:
-    def __init__(self, recipe_name) -> None:
+    def __init__(self, recipe_name, states) -> None:
         self.recipe_json = None
         self.recipe_list = self.get_recipe_list()
         self.recipe_name = recipe_name
@@ -16,6 +16,7 @@ class Recipe:
         else:
             raise KeyError(f"Error: {recipe_name} is not found.")
             
+        self.states = states
         self.variables = {}
         with open(os.path.join("recipes", self.recipe_path), 'r') as f:
             self.recipe_json = json.load(f)
@@ -36,29 +37,36 @@ class Recipe:
         self.variables["input"] = []
         
         for arg_count, arg in enumerate(args):
+            template_arg = utils.replace_template_nostr(self.states, arg)
+            if not template_arg is None:
+                arg = template_arg
             self.variables["input"].append(arg)
             
+        self.variables["inrecipe-names"] = []
         for module in self.recipe_json['execution-chain']:
-            
-
             for arg_count, arg in enumerate(module['arguments']):
                 module['arguments'][arg_count] = utils.replace_template(self.variables, arg)
                     
             if module["type"] == "module":
-                this_execution = md.Module(module["name"])
+                this_execution = md.Module(module["name"], self.states)
             elif module["type"] == "recipe":
-                this_execution = Recipe(module["name"])
+                this_execution = Recipe(module["name"], self.states)
                 
             this_execution.run(module['arguments'])
             self.variables[module["inrecipe-name"]] = {"output": []}
             self.variables[module["inrecipe-name"]]["output"] = this_execution.get_result()
+            self.variables["inrecipe-names"].append(module["inrecipe-name"])
 
             
     def get_result(self):
         self.variables["output"] = []
         for arg_count, arg in enumerate(self.recipe_json['output']):
-            self.variables["output"].append(utils.replace_template(self.variables, arg))
+            self.variables["output"].append(utils.replace_template_nostr(self.variables, arg))
+            
         return self.variables["output"]
+    
+    def get_variables(self):
+        return self.variables
     
     async def run_async(self, args) -> None:
         pass

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -29,6 +29,22 @@ def replace_template(variables, template):
     
     return pattern.sub(replacer, template)
 
+def replace_template_nostr(variables: dict, template: str):
+    if not (template.startswith("{") and template.endswith("}")):
+        return None
+        
+    keys = template.strip("{}").split(".")
+    obj = variables.copy()
+    for key in keys:
+        try:
+            if isinstance(obj, list):  # json_objがリストの場合
+                key = int(key) 
+            obj = obj[key]
+        except (KeyError, IndexError, TypeError):
+            return None  # キーが存在しない場合はNoneを返す
+
+    return obj
+
 def filter_object(obj, allowed_types=(str, int, float, bool, list, dict, type(None))):
     """
     任意のオブジェクトからjsonに変換可能なオブジェクトのみを取り出す

--- a/src/workspace/workspace.py
+++ b/src/workspace/workspace.py
@@ -20,6 +20,8 @@ class WorkSpace:
         self.workspace_id = workspace_id
         #self.workspace_path = workspace_path
         
+        self.variables = {}
+        
     def run_module(self, module_name: str, args: list) -> str:
         """
         モジュールの実行
@@ -31,7 +33,7 @@ class WorkSpace:
         Returns:
             str: モジュール実行id
         """
-        module = Module(module_name)
+        module = Module(module_name, dict(**self.module_state, **self.recipe_state))
         module.run(args)
         module_id = self.get_next_module_id()
         self.module_state[module_id] = {
@@ -81,9 +83,9 @@ class WorkSpace:
         return Module.get_module_info(modulename)
             
     def run_recipe(self, recipe_name: str, args: list) -> str:
-        recipe = Recipe(recipe_name)
-        recipe.run(args)
+        recipe = Recipe(recipe_name, dict(**self.module_state, **self.recipe_state))
         recipe_id = self.get_next_recipe_id()
+        recipe.run(args)
         self.recipe_state[recipe_id]={
                 "recipe" : recipe,
                 "running": False,
@@ -108,6 +110,12 @@ class WorkSpace:
         # del self.recipe_state[id]["recipe"] # レシピは実行後に破棄 todo 後で確認
         
         return self.recipe_state[id]["output"]
+    
+    def get_recipe_variables(self, id) -> object:
+        if id not in self.recipe_state:
+            raise KeyError("recipe_id: {} not found".format(id))
+        
+        return self.recipe_state[id]["recipe"].get_variables()
     
     def get_recipe_state_list(self) -> object:
         return self.recipe_state


### PR DESCRIPTION
各種stateの内容をrecipe moduleから参照可能にした

これに伴って、UI側で各種stateを取得してモジュールID、実行したモジュール名や引数、結果　などを表示する機能が欲しい
これでmodule recipeの起動時の引数に過去の結果を利用できる
run recipe ipinfo {recipe-id.output.0.ip}
みたいな感じに

また、recipe内変数の全てを取得するget_recipe_variablesを新たに実装したので必要なら使って欲しい

